### PR TITLE
[HAWKULAR-21] - adding travis configuration

### DIFF
--- a/.travis.build.plugin.sh
+++ b/.travis.build.plugin.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+#
+# Copyright 2014-2015 Red Hat, Inc. and/or its affiliates
+# and other contributors as indicated by the @author tags.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+pushd $@
+npm install && bower instal && gulp build
+popd

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+language: node_js
+node_js:
+  - '0.10'
+
+before_install:
+  - 'npm install -g bower gulp typescript'
+
+script: 
+    - 'for plugin in $(find plugins/ -maxdepth 1 -mindepth 1); do ./.travis.build.plugin.sh $plugin; done;'
+
+# use this line in case of building only a sub-set of plugins
+#  - 'for plugin in alerts inventory metrics; do ./.travis.build.plugin.sh $plugin; done;'

--- a/README.adoc
+++ b/README.adoc
@@ -1,5 +1,10 @@
 = Hawkular UI Components
 
+ifdef::env-github[]
+[link=https://travis-ci.org/hawkular/hawkular-ui-components]
+image:https://travis-ci.org/hawkular/hawkular-ui-components.svg["Build Status", link="https://travis-ci.org/hawkular/hawkular-ui-components"]
+endif::[]
+
 [.lead]
 *Hawkular UI Components* is the home of UI Components that comprise the Hawkular console for https://github.com/hawkular/hawkular[Hawkular].  This console is based on https://github.com/hawtio/hawtio/blob/master/docs/Overview2dotX.md[Hawt.io 2], which a javascript based client-side framework. The various directories underneath console directory are Hawt.io 2 plugins and the various plugins eventually compose a Hawkular console. This modular approach to creating hawtio console plugins allows us to create individual plugins that comprise a console or can easily  be plugged into other Hawtio based consoles. The plugin system makes it easy to add/remove functionality (even dynamically).
 


### PR DESCRIPTION
for each sub-directory in `plugins` it runs:
`npm install && bower instal && gulp build`

So the testsuite can be part of the build task, or we can create a new one and run it with `gulp test` at the end.

There are currently no notifiers set in the travis config.

example build here:
https://travis-ci.org/Jiri-Kremser/hawkular-ui-components/builds/49636582
