### PR TITLE
Adding quick alert form

### DIFF
--- a/dist/hawkular-ui-components-alerts.js
+++ b/dist/hawkular-ui-components-alerts.js
@@ -280,6 +280,7 @@ var HawkularAlerts;
                 this.$scope.msgs = [];
                 this.HawkularAlert.Trigger.delete({ triggerId: id }, function () {
                     _this.HawkularAlert.Dampening.delete({ triggerId: id }, function () {
+                        _this.deleteAllConditions(id);
                         _this.allDefinitions();
                     }, function (reasonDampening) {
                         _this.addAlertMsg(reasonDampening);
@@ -497,6 +498,23 @@ var HawkularAlerts;
                     _this.addAlertMsg(reasonDelete);
                 });
             }
+        };
+        DefinitionsController.prototype.deleteAllConditions = function (triggerId) {
+            var _this = this;
+            this.HawkularAlert.Trigger.conditions({ triggerId: triggerId }, function (conditionsList) {
+                var conditionClass = {};
+                for (var i = 0; i < conditionsList.length; i++) {
+                    conditionClass[conditionsList[i].conditionId] = conditionsList[i].className;
+                }
+                for (i = 0; i < conditionsList.length; i++) {
+                    var condition = conditionsList[i];
+                    _this.HawkularAlert[condition.className].delete({ conditionId: condition.conditionId }, function (reasonType) {
+                        _this.addAlertMsg(reasonType);
+                    });
+                }
+            }, function (reasonList) {
+                _this.addAlertMsg(reasonList);
+            });
         };
         DefinitionsController.prototype.cancelCondition = function () {
             this.$scope.statusCondition = { status: '' };

--- a/plugins/alerts/plugins/alerts/ts/definitions.ts
+++ b/plugins/alerts/plugins/alerts/ts/definitions.ts
@@ -117,6 +117,7 @@ module HawkularAlerts {
                     () => {
                         this.HawkularAlert.Dampening.delete({triggerId: id},
                             () => {
+                                this.deleteAllConditions(id);
                                 this.allDefinitions();
                             }, (reasonDampening) => {
                                 this.addAlertMsg(reasonDampening);
@@ -359,6 +360,25 @@ module HawkularAlerts {
                 );
 
             }
+        }
+
+        private deleteAllConditions(triggerId: string):void {
+            this.HawkularAlert.Trigger.conditions({triggerId: triggerId},
+                (conditionsList) => {
+                    var conditionClass:any = {};
+                    for (var i = 0; i < conditionsList.length; i++) {
+                        conditionClass[conditionsList[i].conditionId] = conditionsList[i].className;
+                    }
+                    for (i = 0; i < conditionsList.length; i++) {
+                        var condition = conditionsList[i];
+                        this.HawkularAlert[condition.className].delete({conditionId: condition.conditionId},
+                            (reasonType) => {
+                                this.addAlertMsg(reasonType);
+                            });
+                    }
+                }, (reasonList) => {
+                    this.addAlertMsg(reasonList);
+                });
         }
 
         cancelCondition():void {

--- a/plugins/metrics/plugins/metrics/html/metrics-response.html
+++ b/plugins/metrics/plugins/metrics/html/metrics-response.html
@@ -59,4 +59,61 @@
 
 
 </div>
+<div ng-controller="QuickAlertController as qac">
+  <div ng-if="!showQuickAlert" class="col-sm-9 col-md-10 content">
+    <button class="btn btn-primary" ng-click="qac.toggleQuickAlert()">Add an Alert</button>
+  </div>
+  <div ng-if="showQuickAlert" class="col-sm-9 col-md-10 content">
+      <h1>Add an Alert</h1>
+      <form class="form-horizontal" name="addQuickAlertForm" role="form">
+        <div class="form-group">
+          <label class="col-md-4 control-label">
+            Fire when metric is
+          </label>
+          <div class="col-md-6">
+            <label class="radio-inline">
+              <input type="radio" ng-model="quickTrigger.operator" class="radio" value="LT"> <
+            </label>
+            <label class="radio-inline">
+              <input type="radio" ng-model="quickTrigger.operator" class="radio" value="GT"> >
+            </label>
+            <label class="radio-inline">
+              <input type="radio" ng-model="quickTrigger.operator" class="radio" value="LTE"> <=
+            </label>
+            <label class="radio-inline">
+              <input type="radio" ng-model="quickTrigger.operator" class="radio" value="GTE"> >=
+            </label>
+          </div>
+        </div>
+        <div class="form-group">
+          <label class="col-md-4 control-label" for="threshold">
+            Of threshold
+          </label>
+          <div class="col-md-6">
+            <input type="number" id="threshold" ng-model="quickTrigger.threshold" class="form-control" ng-minlength="1" required>
+          </div>
+        </div>
+        <div class="form-group">
+          <label class="col-md-4 control-label" for="notifiers">
+            Notify to:
+          </label>
+          <div class="col-md-6">
+            <ui-select id="notifiers" multiple ng-model="quickTrigger.notifiers" theme="bootstrap" ng-disabled="disabled" close-on-select="false">
+              <ui-select-match placeholder="Select notifier...">{{$item}}</ui-select-match>
+              <ui-select-choices repeat="notifier in notifiers | filter:$select.search">
+                {{ notifier }}
+              </ui-select-choices>
+            </ui-select>
+          </div>
+        </div>
+        <div class="form-group">
+          <div class="col-md-offset-4 col-md-6">
+            <button class="btn btn-primary" ng-click="qac.saveQuickAlert()">Create Alert</button>
+            <button type="button" class="btn btn-default" ng-click="qac.toggleQuickAlert()">Cancel</button>
+          </div>
+        </div>
+      </form>
+  </div>
+</div>
+
 </div>

--- a/plugins/metrics/plugins/metrics/ts/metricsPlugin.ts
+++ b/plugins/metrics/plugins/metrics/ts/metricsPlugin.ts
@@ -18,7 +18,7 @@
 
 module HawkularMetrics {
 
-    export var _module = angular.module(HawkularMetrics.pluginName, ['ngResource','hawkularCharts', 'hawkular.services']);
+    export var _module = angular.module(HawkularMetrics.pluginName, ['ngResource','ui.select', 'hawkularCharts', 'hawkular.services']);
 
     var metricsTab:any;
 

--- a/plugins/metrics/plugins/metrics/ts/metricsResponsePage.ts
+++ b/plugins/metrics/plugins/metrics/ts/metricsResponsePage.ts
@@ -36,6 +36,8 @@ module HawkularMetrics {
         rangeInSeconds:number;
     }
 
+    var sharedMetricId;
+
     /**
      * @ngdoc controller
      * @name ChartController
@@ -193,7 +195,9 @@ module HawkularMetrics {
         }
 
         getMetricId() {
-            return this.isResponseTab ? this.getResourceDurationMetricId() : this.getResourceCodeMetricId();
+            var metricId = this.isResponseTab ? this.getResourceDurationMetricId() : this.getResourceCodeMetricId();
+            sharedMetricId = metricId;
+            return metricId;
         }
 
         private getResourceDurationMetricId() {
@@ -264,5 +268,119 @@ module HawkularMetrics {
     }
 
     _module.controller('MetricsViewController', MetricsViewController);
+
+    export interface IQuickAlertController {
+        toggleQuickAlert():void
+        saveQuickAlert():void
+    }
+
+    export class QuickAlertController implements IQuickAlertController {
+        public static  $inject = ['$scope', 'HawkularAlert'];
+
+        constructor(private $scope:any,
+                    private HawkularAlert: any) {
+            this.$scope.showQuickAlert = false;
+            this.$scope.quickTrigger = {
+                operator: 'LT',
+                threshold: 0
+            };
+            this.allNotifiers();
+            console.log('Notifiers: ' + this.$scope.notifiers);
+        }
+
+        toggleQuickAlert():void {
+            this.$scope.showQuickAlert = !this.$scope.showQuickAlert;
+        }
+
+        private allNotifiers():void {
+            this.$scope.notifiers = [];
+            this.HawkularAlert.Notifier.query(
+                (result) => {
+                    this.$scope.notifiers = result;
+                }, (error) => {
+                    if (error.data.errorMsg) {
+                        toastr.error(error.data.errorMsg);
+                    } else {
+                        toastr.error('Error loading Alerts Notifiers: ' + error);
+                    }
+                }
+            );
+        }
+
+        saveQuickAlert():void {
+            if (sharedMetricId !== '.status.duration' && sharedMetricId !== '.status.code') {
+                var newTrigger:any = {};
+                newTrigger.id = sharedMetricId + 'ResponseTime' + '-' + this.$scope.quickTrigger.operator + '-' + this.$scope.quickTrigger.threshold;
+                newTrigger.name = newTrigger.id;
+                newTrigger.description = 'Created on ' + new Date();
+                newTrigger.match = 'ALL';
+                newTrigger.enabled = true;
+                newTrigger.notifiers = this.$scope.quickTrigger.notifiers;
+
+                var newDampening:any = { triggerId: newTrigger.id,
+                    type: 'RELAXED_COUNT',
+                    evalTrueSetting: 1,
+                    evalTotalSetting: 1,
+                    evalTimeSetting: 0
+                };
+
+                this.HawkularAlert.Trigger.save(newTrigger,
+                    (trigger) => {
+                        newDampening.triggerId = trigger.id;
+                        this.HawkularAlert.Dampening.save(newDampening,
+                            (dampening) => {
+                                var newThresholdCondition = {
+                                    triggerId: newDampening.triggerId,
+                                    dataId: sharedMetricId,
+                                    conditionSetSize: 1,
+                                    conditionSetIndex: 1,
+                                    operator: this.$scope.quickTrigger.operator,
+                                    threshold: this.$scope.quickTrigger.threshold
+                                };
+                                this.HawkularAlert['ThresholdCondition'].save(newThresholdCondition,
+                                    () => {
+                                        this.HawkularAlert.Alert.reload(
+                                            (errorReload) => {
+                                                if (errorReload.data.errorMsg) {
+                                                    toastr.error(errorReload.data.errorMsg);
+                                                } else {
+                                                    toastr.error('Error reloading alerts' + errorReload);
+                                                }
+                                            });
+                                        this.toggleQuickAlert();
+                                    },
+                                    (errorCondition) => {
+                                        if (errorCondition.data.errorMsg) {
+                                            toastr.error(errorCondition.data.errorMsg);
+                                        } else {
+                                            toastr.error('Error loading Saving Trigger Condition' + errorCondition);
+                                        }
+                                    });
+                            }, (errorDampening) => {
+                                if (errorDampening.data.errorMsg) {
+                                    toastr.error(errorDampening.data.errorMsg);
+                                } else {
+                                    toastr.error('Error loading Saving Trigger Dampening ' + errorDampening);
+                                }
+                            }
+                        );
+                    }, (error) => {
+                        if (error.data.errorMsg) {
+                            toastr.error(error.data.errorMsg);
+                        } else {
+                            toastr.error('Error loading Saving Trigger ' + error);
+                        }
+                    }
+                );
+            } else {
+                toastr.warning('No metric selected');
+            }
+
+        }
+
+    }
+
+    _module.controller('QuickAlertController', QuickAlertController);
+
 
 }


### PR DESCRIPTION
This PR adds a quick alert form in the Metric ResponseTime page.
It is a shortcut to create trigger definitions for threshold conditions only.
