### PR TITLE
Add back in bootstrap to bower because directives plugin uses bootstrap ...

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -23,6 +23,7 @@
     "!dist/*"
   ],
   "dependencies": {
+    "bootstrap": "3.3.2",
     "angular-bootstrap": "0.11.0",
     "angular-ui-select": "0.11.2",
     "bootstrap-select": "1.6",


### PR DESCRIPTION
...variables.less in main.less.

These build issues are not visible in local builds.
