### PR TITLE
Change metrics response page to pull resourceId from Url

### DIFF
--- a/plugins/metrics/plugins/metrics/ts/metricsResponsePage.ts
+++ b/plugins/metrics/plugins/metrics/ts/metricsResponsePage.ts
@@ -164,11 +164,11 @@ module HawkularMetrics {
     }
 
     getMetricId():string {
-      return MetricsViewController.getResourceDurationMetricId();
+      return this.getResourceDurationMetricId();
     }
 
-    private static getResourceDurationMetricId() {
-      return globalMetricId + '.status.duration';
+    private getResourceDurationMetricId() {
+      return this.$routeParams.resourceId +  '.status.duration';
     }
 
     refreshSummaryData(metricId:string, startTime?:number, endTime?:number):void {


### PR DESCRIPTION
So we don't have to pass state around, it is contained in the url. This makes linking/bookmarking possible.
Example: http://localhost:2772/metrics/responseTime/x1427317760224/.
