### PR TITLE
Console: Fix delete URL

### DIFF
--- a/plugins/metrics/plugins/metrics/html/modals/delete-resource.html
+++ b/plugins/metrics/plugins/metrics/html/modals/delete-resource.html
@@ -6,7 +6,7 @@
 </div>
 <div class="modal-body">
   <div class="form-group">
-    <p class="primary-message">Are you sure you want to stop monitoring and delete the data for the site <strong>{{ vm.resource.parameters.url }}</strong> (Resource ID: {{ vm.resource.id }}) ?</p>
+    <p class="primary-message">Are you sure you want to stop monitoring and delete the data for the site <strong>{{ vm.resource.properties.url }}</strong> (Resource ID: {{ vm.resource.id }}) ?</p>
     <p>This action can't be undone.</p>
   </div>
 </div>

--- a/plugins/metrics/plugins/metrics/ts/addUrlPage.ts
+++ b/plugins/metrics/plugins/metrics/ts/addUrlPage.ts
@@ -110,13 +110,13 @@ module HawkularMetrics {
           }];
 
           var errMetric = (error: any) => err(error, 'Error saving metric.');
-          var createMetric = (metric: any) => 
+          var createMetric = (metric: any) =>
             this.HawkularInventory.Metric.save({
               tenantId: globalTenantId,
               environmentId: globalEnvironmentId
             }, metric).$promise;
 
-          var associateResourceWithMetrics = () => 
+          var associateResourceWithMetrics = () =>
             this.HawkularInventory.ResourceMetric.save({
               tenantId: globalTenantId,
               environmentId: globalEnvironmentId,
@@ -132,19 +132,19 @@ module HawkularMetrics {
         })
 
         // Find if a default email exists
-        .then(() => this.HawkularAlertsManager.addEmailAction(defaultEmail), 
+        .then(() => this.HawkularAlertsManager.addEmailAction(defaultEmail),
           (e) => err(e, 'Error during saving metrics.'))
 
         // Create threshold trigger for newly created metrics
-        .then(() => this.HawkularAlertsManager.createTrigger(metricId + '_trigger_thres', true, 'THRESHOLD', defaultEmail), 
+        .then(() => this.HawkularAlertsManager.createTrigger(metricId + '_trigger_thres', true, 'THRESHOLD', defaultEmail),
           (e) => err(e, 'Error saving email action.'))
 
         // Create availability trigger for newly created metrics
-        .then((alert) => this.HawkularAlertsManager.createTrigger(metricId + '_trigger_avail', false, 'AVAILABILITY', defaultEmail), 
+        .then((alert) => this.HawkularAlertsManager.createTrigger(metricId + '_trigger_avail', false, 'AVAILABILITY', defaultEmail),
           (e) => err(e, 'Error saving threshold trigger.'))
 
         //this.$location.url('/hawkular/' + metricId);
-        .then(() => toastr.info('Your data is being collected. Please be patient (should be about another minute).'), 
+        .then(() => toastr.info('Your data is being collected. Please be patient (should be about another minute).'),
           (e) => err(e, 'Error saving availability trigger.'))
 
         .finally(()=> {
@@ -231,7 +231,7 @@ module HawkularMetrics {
         environmentId: globalEnvironmentId,
         resourceId: this.resource.id
       }).$promise.then((res) => {
-          toastr.info('The site ' + this.resource.parameters.url + ' is no longer being monitored.');
+          toastr.info('The site ' + this.resource.properties.url + ' is no longer being monitored.');
           this.$modalInstance.close(res);
       });
     }


### PR DESCRIPTION
When deleting a site, the modal was missing the URL information and after deleting was not closing the modal. This was due to recent changes to json object structure (parameters => properties).
