### PR TITLE
Fixed async file paths adjusting in gulp script

### DIFF
--- a/build/gulpfile.js
+++ b/build/gulpfile.js
@@ -35,17 +35,6 @@ module.exports = function(gulp, config, pluginName){
   var plugins = gulpLoadPlugins({});
   var isWatch = false;
 
-  /** Adjust the reference path of any typescript-built plugin this project depends on */
-  gulp.task('path-adjust', function() {
-    gulp.src('libs/**/includes.d.ts')
-      .pipe(map(function(buf, filename) {
-        var textContent = buf.toString();
-        var newTextContent = textContent.replace(/"\.\.\/libs/gm, '"../../../libs');
-        return newTextContent;
-      }))
-      .pipe(gulp.dest('libs'));
-  });
-
   gulp.task('clean-defs', function() {
     del(['.tmp/' + pluginName + 'defs.d.ts']);
   });
@@ -192,7 +181,7 @@ module.exports = function(gulp, config, pluginName){
     // For directives
     for(var i =0; i < watchList.length; i++) {
       (function(plugin) {
-        plugins.watch(['libs/**/*.d.ts', config.ts(plugin), config.templates(plugin)], function () {
+        plugins.watch([config.ts(plugin), config.templates(plugin)], function () {
           gulp.start(['tslint-watch-' + plugin, 'tsc-' + plugin, 'template-' + plugin, 'concat-' + plugin,
             'clean-' + plugin, 'connect-prepare-dist-' + plugin]);
         });

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -19,6 +19,7 @@ var gulp = require('gulp'),
     del = require('del'),
     wiredep = require('wiredep').stream,
     plugins = require('gulp-load-plugins')({}),
+    map = require('vinyl-map'),
     fs = require('fs'),
     path = require('path');
 
@@ -64,6 +65,18 @@ for (var i = 0; i < pluginFolders.length; i++){
   taskCreator(gulp, config, pluginName);
   pluginBuildTasks.push('build-' + pluginName);
 }
+
+/** Adjust the reference path of any typescript-built plugin this project depends on */
+gulp.task('path-adjust', function(done) {
+  gulp.src('libs/**/includes.d.ts')
+    .pipe(map(function(buf, filename) {
+      var textContent = buf.toString();
+      var newTextContent = textContent.replace(/"\.\.\/libs/gm, '"../../../libs');
+      return newTextContent;
+    }))
+    .pipe(gulp.dest('libs'))
+    .on('end', function() {done()});
+});
 
 gulp.task('reload', function() {
   var staticPath = path.resolve(__dirname, '.tmp/gulp-connect-server/');


### PR DESCRIPTION
This should fix the failing builds. The problem was in async task adjusting reference paths in libraries. Using the callback done() function after receiving the 'end' event should assure the task completion after the next one (tsc-*) starts.
